### PR TITLE
Append the messages array when receive a new create record

### DIFF
--- a/Swift Chat Demo/MessagesViewController.swift
+++ b/Swift Chat Demo/MessagesViewController.swift
@@ -62,6 +62,12 @@ class MessagesViewController: JSQMessagesViewController {
 
         messageObserver = chat.subscribeToMessages(in: userConversation.conversation, handler: { (event, message) in
             print("Received message event")
+            if event == SKYChatRecordChangeEvent.create && !self.messages.contains(message) && message.creatorUserRecordID != SKYContainer.default().currentUserRecordID
+            {
+                self.messages.append(message)
+                self.reloadViews()
+                self.finishReceivingMessage(animated: true)
+            }
         })
         typingObserver = chat.subscribeToTypingIndicator(in: userConversation.conversation, handler: { (indicator) in
             print("Receiving typing event")
@@ -136,6 +142,7 @@ class MessagesViewController: JSQMessagesViewController {
 
                                 if let messages = messages {
                                     self.messages = messages.reversed()
+                                    self.finishReceivingMessage(animated: false)
                                     self.reloadViews()
                                 }
         })


### PR DESCRIPTION
- Will append the messages array when receive a message (only when the record change event is create, the array does not contain that message and the message is sent) The message sent is already append to the messages array when press the "Send" button
- Scroll to the latest message when finish fetching for better UX